### PR TITLE
JMK type fixes

### DIFF
--- a/gromacs/protocols/protocol_MD_simulation.py
+++ b/gromacs/protocols/protocol_MD_simulation.py
@@ -281,7 +281,9 @@ class GromacsMDSimulation(EMProtocol):
         warns = []
         #Global warnings
         inpSystem = self.gromacsSystem.get()
-        if str(inpSystem.getForceField()).startswith('gromos'):
+        if inpSystem is None:
+            warns.append('\nPlease provide a gromacs system as input')            
+        elif str(inpSystem.getForceField()).startswith('gromos'):
             warns.append('\nStep all : GROMOS force field is not recommended by GROMACS: '
                          'https://chemrxiv.org/engage/chemrxiv/article-details/60c74701bdbb895afaa38ce2')
         elif str(inpSystem.getForceField()).startswith('charmm36') and 'CA' in inpSystem.getIons() and \

--- a/gromacs/protocols/protocol_MD_simulation.py
+++ b/gromacs/protocols/protocol_MD_simulation.py
@@ -92,7 +92,6 @@ class GromacsMDSimulation(EMProtocol):
 
         form.addParam('gromacsSystem', params.PointerParam, label="Input Gromacs System: ",
                       pointerClass='GromacsSystem',
-                      allowsNull=True,
                       help='Gromacs solvated system to be simulated')
         form.addParam('integrator', params.EnumParam,
                        label='Simulation integrator: ',
@@ -281,9 +280,7 @@ class GromacsMDSimulation(EMProtocol):
         warns = []
         #Global warnings
         inpSystem = self.gromacsSystem.get()
-        if inpSystem is None:
-            warns.append('\nPlease provide a gromacs system as input')            
-        elif str(inpSystem.getForceField()).startswith('gromos'):
+        if str(inpSystem.getForceField()).startswith('gromos'):
             warns.append('\nStep all : GROMOS force field is not recommended by GROMACS: '
                          'https://chemrxiv.org/engage/chemrxiv/article-details/60c74701bdbb895afaa38ce2')
         elif str(inpSystem.getForceField()).startswith('charmm36') and 'CA' in inpSystem.getIons() and \

--- a/gromacs/wizards/wizard_MDSimulation.py
+++ b/gromacs/wizards/wizard_MDSimulation.py
@@ -54,27 +54,28 @@ class GromacsWatchRelaxStepWizard(pwizard.Wizard):
     def show(self, form, *params):
         protocol = form.protocol
         watchStep = protocol.watchStep.get().strip()
-        if watchStep == "":
-            watchStep = 0
-        index = int(watchStep)
-        if protocol.countSteps() >= index > 0:
-            workSteps = protocol.workFlowSteps.get().split('\n')
-            msjDic = eval(workSteps[index - 1])
-            for pName in msjDic:
-                if pName in protocol._paramNames:
-                    form.setVar(pName, msjDic[pName])
-                elif pName in protocol._enumParamNames:
-                    if pName == 'integrator':
-                        idx = protocol._integrators.index(msjDic[pName])
-                    elif pName == 'ensemType':
-                        idx = protocol._ensemTypes.index(msjDic[pName])
-                    elif pName == 'thermostat':
-                        idx = protocol._thermostats.index(msjDic[pName])
-                    elif pName == 'barostat':
-                        idx = protocol._barostats.index(msjDic[pName])
-                    elif pName == 'coupleStyle':
-                        idx = protocol._coupleStyle.index(msjDic[pName])
-                    elif pName == 'restrains':
-                        idx = protocol._restrainTypes.index(msjDic[pName])
-                    form.setVar(pName, idx)
+        try:
+            index = int(watchStep)
+            if protocol.countSteps() >= index > 0:
+                workSteps = protocol.workFlowSteps.get().split('\n')
+                msjDic = eval(workSteps[index - 1])
+                for pName in msjDic:
+                    if pName in protocol._paramNames:
+                        form.setVar(pName, msjDic[pName])
+                    elif pName in protocol._enumParamNames:
+                        if pName == 'integrator':
+                            idx = protocol._integrators.index(msjDic[pName])
+                        elif pName == 'ensemType':
+                            idx = protocol._ensemTypes.index(msjDic[pName])
+                        elif pName == 'thermostat':
+                            idx = protocol._thermostats.index(msjDic[pName])
+                        elif pName == 'barostat':
+                            idx = protocol._barostats.index(msjDic[pName])
+                        elif pName == 'coupleStyle':
+                            idx = protocol._coupleStyle.index(msjDic[pName])
+                        elif pName == 'restrains':
+                            idx = protocol._restrainTypes.index(msjDic[pName])
+                        form.setVar(pName, idx)
+        except:
+            print('Index "{}" not recognized as integer'.format(watchStep))
 

--- a/gromacs/wizards/wizard_MDSimulation.py
+++ b/gromacs/wizards/wizard_MDSimulation.py
@@ -53,7 +53,10 @@ class GromacsWatchRelaxStepWizard(pwizard.Wizard):
 
     def show(self, form, *params):
         protocol = form.protocol
-        index = int(protocol.watchStep.get().strip())
+        watchStep = protocol.watchStep.get().strip()
+        if watchStep == "":
+            watchStep = 0
+        index = int(watchStep)
         if protocol.countSteps() >= index > 0:
             workSteps = protocol.workFlowSteps.get().split('\n')
             msjDic = eval(workSteps[index - 1])

--- a/gromacs/wizards/wizard_MDSimulation.py
+++ b/gromacs/wizards/wizard_MDSimulation.py
@@ -77,5 +77,5 @@ class GromacsWatchRelaxStepWizard(pwizard.Wizard):
                             idx = protocol._restrainTypes.index(msjDic[pName])
                         form.setVar(pName, idx)
         except:
-            print('Index "{}" not recognized as integer'.format(watchStep))
+            print('Index "{}" not recognized as integer for watch step'.format(watchStep))
 


### PR DESCRIPTION
Somewhat fixes errors that only arrive in the terminal:

```
Incorrect index
Exception in Tkinter callback
Traceback (most recent call last):
  File "/home/jkrieger/anaconda3/envs/scipion3/lib/python3.8/tkinter/__init__.py", line 1892, in __call__
    return self.func(*args)
  File "/mnt/c/Users/james/code/scipion3_new/scipion-pyworkflow/pyworkflow/gui/form.py", line 1099, in _showWizard
    wizard.show(self.window)
  File "/mnt/c/Users/james/code/scipion3_new/scipion-em-plugins/scipion-chem-gromacs/gromacs/wizards/wizard_MDSimulation.py", line 56, in show
    index = int(protocol.watchStep.get().strip())
ValueError: invalid literal for int() with base 10: ''
```

```
Exception in Tkinter callback
Traceback (most recent call last):
  File "/home/jkrieger/anaconda3/envs/scipion3/lib/python3.8/tkinter/__init__.py", line 1892, in __call__
    return self.func(*args)
  File "/mnt/c/Users/james/code/scipion3_new/scipion-pyworkflow/pyworkflow/gui/form.py", line 2261, in execute
    warns = self.protocol.warnings()
  File "/mnt/c/Users/james/code/scipion3_new/scipion-pyworkflow/pyworkflow/protocol/protocol.py", line 1988, in warnings
    return self._warnings()
  File "/mnt/c/Users/james/code/scipion3_new/scipion-em-plugins/scipion-chem-gromacs/gromacs/protocols/protocol_MD_simulation.py", line 284, in _warnings
    if str(inpSystem.getForceField()).startswith('gromos'):
AttributeError: 'NoneType' object has no attribute 'getForceField'
```