### PR TITLE
set output filename to ori GroFile not local last one

### DIFF
--- a/gromacs/protocols/protocol_MD_simulation.py
+++ b/gromacs/protocols/protocol_MD_simulation.py
@@ -251,7 +251,7 @@ class GromacsMDSimulation(EMProtocol):
 
         outTrj = self.concatTrjFiles(outTrj='outputTrajectory.xtc', tprFile=lastTprFile)
 
-        outSystem = GromacsSystem(filename=localGroFile, oriStructFile=oriGroFile,
+        outSystem = GromacsSystem(filename=oriGroFile, oriStructFile=oriGroFile,
                                   tprFile=lastTprFile)
         outSystem.setTopologyFile(localTopFile)
         outSystem.setChainNames(self.gromacsSystem.get().getChainNames())


### PR DESCRIPTION
The current configuration has the system file set as the local gro file, which comes from the end of the last step, and this results in a trajectory in VMD that has the last structure as the first structure so the protein RMSD profile is rather strange and converges back to zero and greatly contrasts with the one from gromacs analysis (and ProDy and MDTraj):
![bad_gromacs_vmd](https://user-images.githubusercontent.com/13259162/213750169-5e81cf1d-5d76-439d-8947-86ec743355a5.png)

The fix makes the system file be the original gro file so the trajectory in VMD has the right starting structure and resultant protein RMSD profile (note this is an independent trajectory with the same steps from the same system preparation, so follows a similar trend only):
![good_gromacs_vmd](https://user-images.githubusercontent.com/13259162/213750892-6706a9fe-f4ae-4707-a788-808dc2e2d494.png)
