### PR TITLE
Ja renumbering gro

### DIFF
--- a/gromacs/protocols/protocol_system_prep.py
+++ b/gromacs/protocols/protocol_system_prep.py
@@ -802,7 +802,7 @@ class GromacsSystemPrep(ProtocolLigandParametrization):
         """Return True if two or more chains share at least one residue number (e.g. two chains both
         numbered 1-99). """
         parser = PDB.PDBParser(QUIET=True)
-        model = list(parser.get_structure('protein', inPdb))[0]
+        model = next(iter(parser.get_structure('protein', inPdb)))
 
         seen = set()
         for chain in model:
@@ -820,7 +820,7 @@ class GromacsSystemPrep(ProtocolLigandParametrization):
         parser = PDB.PDBParser(QUIET=True)
         structure = parser.get_structure('protein', inPdb)
         # Renumber only the first model (the one pdb2gmx will read)
-        model = list(structure)[0]
+        model = next(iter(structure))
         residues = list(model.get_residues())
         startNum = residues[0].id[1]
         # Two loops are required so we first park every residue at a temporary number

--- a/gromacs/protocols/protocol_system_prep.py
+++ b/gromacs/protocols/protocol_system_prep.py
@@ -822,6 +822,7 @@ class GromacsSystemPrep(ProtocolLigandParametrization):
         # Renumber only the first model (the one pdb2gmx will read)
         model = list(structure)[0]
         residues = list(model.get_residues())
+        startNum = residues[0].id[1]
         # Two loops are required so we first park every residue at a temporary number
         # (100000 + i), guaranteed free and far above any real residue number, and then assign the final.
         for i, res in enumerate(residues):

--- a/gromacs/protocols/protocol_system_prep.py
+++ b/gromacs/protocols/protocol_system_prep.py
@@ -170,6 +170,17 @@ class GromacsSystemPrep(ProtocolLigandParametrization):
                             'preserving the real N- and C-termini uncapped. '
                             '\n*All termini*: Add caps to both gaps and real protein termini.')
 
+        form.addParam('renumberRes', params.BooleanParam, default=True,
+                      label='Renumber residues continuously: ',
+                      help='Renumber the residues of the input structure continuously across all chains before '
+                           'running "gmx pdb2gmx -merge all". \nWhen a structure has several chains that share the '
+                           'same residue numbering (e.g. two chains both numbered 1-99), merging them into a single '
+                           'GROMACS molecule produces a .gro file with repeated residue numbers, which breaks the '
+                           'downstream output analysis (RMSF, per-residue selections, residue restraints...). '
+                           '\nWith this option each chain continues the numbering of the previous one (chain A: 1-99, '
+                           'chain B: 100-198...), so the resulting .gro has unique residue numbers. The original '
+                           'numbering of the first residue is preserved.')
+
         self._defineACPYPEparams(form, condition=f'inputFrom=={LIGAND}')
 
         form.addSection('MD prep')
@@ -340,6 +351,10 @@ class GromacsSystemPrep(ProtocolLigandParametrization):
             self.runPymol(self.addCapsPml(inputStructure, cappedPdb, mode), self._getExtraPath())
             self.fixPdbTER(cappedPdb)
             inputStructure = cappedPdb
+
+        if self.renumberRes.get():
+            renumberedPdb = os.path.abspath(self._getExtraPath(f'{systemBasename}_renumbered.pdb'))
+            inputStructure = self.renumberResiduesPDB(inputStructure, renumberedPdb)
 
         Waterff = GROMACS_WATERFF_NAME[self.waterForceField.get()]
         Mainff = GROMACS_MAINFF_NAME[self.mainForceField.get()]
@@ -791,6 +806,44 @@ class GromacsSystemPrep(ProtocolLigandParametrization):
 
         with open(pdbPath, 'w') as f:
             f.writelines(fixedLines)
+
+    def renumberResiduesPDB(self, inPdb, outPdb):
+        """Renumber the residues of a PDB continuously across all chains so that, after merging the chains
+        with "gmx pdb2gmx -merge all", the resulting .gro does not contain repeated residue numbers.
+
+        Each chain continues the numbering of the previous one (e.g. chain A: 1-99, chain B: 100-198), and
+        insertion codes are cleared. The numbering of the very first residue is preserved as the starting point.
+        """
+        parser = PDB.PDBParser(QUIET=True)
+        structure = parser.get_structure('protein', inPdb)
+        # Renumber only the first model (the one pdb2gmx will read)
+        model = list(structure)[0]
+
+        residues = list(model.get_residues())
+        if not residues:
+            self._log.warning('No residues found while renumbering, keeping the original structure')
+            return inPdb
+
+        # Preserve the starting number of the first residue (e.g. 1)
+        startNum = residues[0].id[1]
+
+        # First pass: move every residue to a temporary, collision-free numbering. Renumbering in place can
+        # clash with residues that still keep their original number within the same chain (e.g. shifting
+        # chain B residue 1 -> 100 when residue 100 does not exist is safe, but smaller shifts are not).
+        for i, res in enumerate(residues):
+            res.id = (res.id[0], 100000 + i, ' ')
+
+        # Second pass: assign the final continuous numbering across all chains
+        num = startNum
+        for res in residues:
+            res.id = (res.id[0], num, ' ')
+            num += 1
+
+        io = PDB.PDBIO()
+        io.set_structure(structure)
+        io.save(outPdb)
+        self._log.info(f'Residues renumbered continuously ({startNum}-{num - 1}) into {outPdb}')
+        return outPdb
 
     def countSSBonds(self, inputStructure, waterff='spc', mainff='amber03'):
         """

--- a/gromacs/protocols/protocol_system_prep.py
+++ b/gromacs/protocols/protocol_system_prep.py
@@ -170,17 +170,6 @@ class GromacsSystemPrep(ProtocolLigandParametrization):
                             'preserving the real N- and C-termini uncapped. '
                             '\n*All termini*: Add caps to both gaps and real protein termini.')
 
-        form.addParam('renumberRes', params.BooleanParam, default=True,
-                      label='Renumber residues continuously: ',
-                      help='Renumber the residues of the input structure continuously across all chains before '
-                           'running "gmx pdb2gmx -merge all". \nWhen a structure has several chains that share the '
-                           'same residue numbering (e.g. two chains both numbered 1-99), merging them into a single '
-                           'GROMACS molecule produces a .gro file with repeated residue numbers, which breaks the '
-                           'downstream output analysis (RMSF, per-residue selections, residue restraints...). '
-                           '\nWith this option each chain continues the numbering of the previous one (chain A: 1-99, '
-                           'chain B: 100-198...), so the resulting .gro has unique residue numbers. The original '
-                           'numbering of the first residue is preserved.')
-
         self._defineACPYPEparams(form, condition=f'inputFrom=={LIGAND}')
 
         form.addSection('MD prep')
@@ -352,7 +341,9 @@ class GromacsSystemPrep(ProtocolLigandParametrization):
             self.fixPdbTER(cappedPdb)
             inputStructure = cappedPdb
 
-        if self.renumberRes.get():
+        # Chains that share residue numbers (e.g. two chains both numbered 1-99) would break the output
+        # analysis. Detect that overlap and, only then, renumber the residues continuously.
+        if self.chainsHaveOverlappingResNumbers(inputStructure):
             renumberedPdb = os.path.abspath(self._getExtraPath(f'{systemBasename}_renumbered.pdb'))
             inputStructure = self.renumberResiduesPDB(inputStructure, renumberedPdb)
 
@@ -807,42 +798,41 @@ class GromacsSystemPrep(ProtocolLigandParametrization):
         with open(pdbPath, 'w') as f:
             f.writelines(fixedLines)
 
+    def chainsHaveOverlappingResNumbers(self, inPdb):
+        """Return True if two or more chains share at least one residue number (e.g. two chains both
+        numbered 1-99). """
+        parser = PDB.PDBParser(QUIET=True)
+        model = list(parser.get_structure('protein', inPdb))[0]
+
+        seen = set()
+        for chain in model:
+            # res.id is (hetero-flag, residue_number, insertion_code); res.id[1] is the residue number
+            chainNums = {res.id[1] for res in chain}
+            if seen & chainNums:
+                return True
+            seen |= chainNums
+        return False
+
     def renumberResiduesPDB(self, inPdb, outPdb):
         """Renumber the residues of a PDB continuously across all chains so that, after merging the chains
         with "gmx pdb2gmx -merge all", the resulting .gro does not contain repeated residue numbers.
-
-        Each chain continues the numbering of the previous one (e.g. chain A: 1-99, chain B: 100-198), and
-        insertion codes are cleared. The numbering of the very first residue is preserved as the starting point.
         """
         parser = PDB.PDBParser(QUIET=True)
         structure = parser.get_structure('protein', inPdb)
         # Renumber only the first model (the one pdb2gmx will read)
         model = list(structure)[0]
-
         residues = list(model.get_residues())
-        if not residues:
-            self._log.warning('No residues found while renumbering, keeping the original structure')
-            return inPdb
-
-        # Preserve the starting number of the first residue (e.g. 1)
-        startNum = residues[0].id[1]
-
-        # First pass: move every residue to a temporary, collision-free numbering. Renumbering in place can
-        # clash with residues that still keep their original number within the same chain (e.g. shifting
-        # chain B residue 1 -> 100 when residue 100 does not exist is safe, but smaller shifts are not).
+        # Two loops are required so we first park every residue at a temporary number
+        # (100000 + i), guaranteed free and far above any real residue number, and then assign the final.
         for i, res in enumerate(residues):
             res.id = (res.id[0], 100000 + i, ' ')
-
-        # Second pass: assign the final continuous numbering across all chains
-        num = startNum
-        for res in residues:
-            res.id = (res.id[0], num, ' ')
-            num += 1
+        for offset, res in enumerate(residues):
+            res.id = (res.id[0], startNum + offset, ' ')
 
         io = PDB.PDBIO()
         io.set_structure(structure)
         io.save(outPdb)
-        self._log.info(f'Residues renumbered continuously ({startNum}-{num - 1}) into {outPdb}')
+        self._log.info(f'Residues renumbered continuously into {outPdb}')
         return outPdb
 
     def countSSBonds(self, inputStructure, waterff='spc', mainff='amber03'):

--- a/gromacs/tests/tests.py
+++ b/gromacs/tests/tests.py
@@ -24,7 +24,7 @@
 # *
 # **************************************************************************
 
-import os
+import os, logging, tempfile
 
 from pyworkflow.tests import BaseTest, setupTestProject, DataSet
 from pwem.protocols import ProtImportPdb
@@ -196,3 +196,60 @@ class TestGromacsMMPBSA(TestGromacsRunSimulation, TestExtractLigand):
         protInt = self._runInteractions(protExtract, inputFrom=LIGAND)
         self._waitOutput(protInt, 'outputSmallMolecules', sleepTime=10)
         self.assertIsNotNone(getattr(protInt, 'outputSmallMolecules', None))
+
+
+class TestGromacsRenumberResidues(BaseTest):
+    """Unit test for the continuous residue renumbering performed during system preparation.
+    It does not require the GROMACS binaries, only Biopython, since it exercises
+    GromacsSystemPrep.renumberResiduesPDB directly."""
+
+    @staticmethod
+    def _writeTwoChainPDB(path):
+        """Two chains (A, B) that BOTH restart their residue numbering at 1, reproducing the situation
+        where merging the chains yields a .gro with repeated residue numbers."""
+        def atom(serial, name, resname, chain, resseq, x, y, z, elem):
+            return (f"ATOM  {serial:>5} {name:<4} {resname:>3} {chain}{resseq:>4}    "
+                    f"{x:8.3f}{y:8.3f}{z:8.3f}  1.00  0.00          {elem:>2}\n")
+
+        lines, serial = [], 1
+        for chain in ('A', 'B'):
+            for resseq, resname in [(1, 'PRO'), (2, 'GLN'), (3, 'ILE')]:
+                for name, elem in [('N', 'N'), ('CA', 'C'), ('C', 'C'), ('O', 'O')]:
+                    lines.append(atom(serial, name, resname, chain, resseq,
+                                       serial * 0.1, serial * 0.1, serial * 0.1, elem))
+                    serial += 1
+            lines.append("TER\n")
+        lines.append("END\n")
+        with open(path, 'w') as f:
+            f.writelines(lines)
+
+    @staticmethod
+    def _chainResNums(pdb):
+        from Bio import PDB
+        structure = PDB.PDBParser(QUIET=True).get_structure('x', pdb)
+        return {ch.id: [r.id[1] for r in ch] for ch in list(structure)[0]}
+
+    def test(self):
+        from gromacs.protocols.protocol_system_prep import GromacsSystemPrep
+
+        inPdb = os.path.join(tempfile.mkdtemp(), 'two_chain_dup.pdb')
+        outPdb = inPdb.replace('_dup.pdb', '_renum.pdb')
+        self._writeTwoChainPDB(inPdb)
+
+        # before: both chains numbered 1-3 (duplicates across chains)
+        before = self._chainResNums(inPdb)
+        self.assertEqual(before['A'], [1, 2, 3])
+        self.assertEqual(before['B'], [1, 2, 3])
+
+        # run the real method with a minimal object (it only needs self._log)
+        class _Fake:
+            _log = logging.getLogger('test')
+        GromacsSystemPrep.renumberResiduesPDB(_Fake(), inPdb, outPdb)
+
+        after = self._chainResNums(outPdb)
+        allNums = [n for nums in after.values() for n in nums]
+        # no duplicates, continuous from the original start, chains preserved
+        self.assertEqual(len(allNums), len(set(allNums)), 'Duplicate residue numbers remain')
+        self.assertEqual(allNums, list(range(1, len(allNums) + 1)))
+        self.assertEqual(after['A'], [1, 2, 3])
+        self.assertEqual(after['B'], [4, 5, 6])

--- a/gromacs/tests/tests.py
+++ b/gromacs/tests/tests.py
@@ -24,7 +24,7 @@
 # *
 # **************************************************************************
 
-import os, logging, tempfile
+import os
 
 from pyworkflow.tests import BaseTest, setupTestProject, DataSet
 from pwem.protocols import ProtImportPdb
@@ -196,60 +196,3 @@ class TestGromacsMMPBSA(TestGromacsRunSimulation, TestExtractLigand):
         protInt = self._runInteractions(protExtract, inputFrom=LIGAND)
         self._waitOutput(protInt, 'outputSmallMolecules', sleepTime=10)
         self.assertIsNotNone(getattr(protInt, 'outputSmallMolecules', None))
-
-
-class TestGromacsRenumberResidues(BaseTest):
-    """Unit test for the continuous residue renumbering performed during system preparation.
-    It does not require the GROMACS binaries, only Biopython, since it exercises
-    GromacsSystemPrep.renumberResiduesPDB directly."""
-
-    @staticmethod
-    def _writeTwoChainPDB(path):
-        """Two chains (A, B) that BOTH restart their residue numbering at 1, reproducing the situation
-        where merging the chains yields a .gro with repeated residue numbers."""
-        def atom(serial, name, resname, chain, resseq, x, y, z, elem):
-            return (f"ATOM  {serial:>5} {name:<4} {resname:>3} {chain}{resseq:>4}    "
-                    f"{x:8.3f}{y:8.3f}{z:8.3f}  1.00  0.00          {elem:>2}\n")
-
-        lines, serial = [], 1
-        for chain in ('A', 'B'):
-            for resseq, resname in [(1, 'PRO'), (2, 'GLN'), (3, 'ILE')]:
-                for name, elem in [('N', 'N'), ('CA', 'C'), ('C', 'C'), ('O', 'O')]:
-                    lines.append(atom(serial, name, resname, chain, resseq,
-                                       serial * 0.1, serial * 0.1, serial * 0.1, elem))
-                    serial += 1
-            lines.append("TER\n")
-        lines.append("END\n")
-        with open(path, 'w') as f:
-            f.writelines(lines)
-
-    @staticmethod
-    def _chainResNums(pdb):
-        from Bio import PDB
-        structure = PDB.PDBParser(QUIET=True).get_structure('x', pdb)
-        return {ch.id: [r.id[1] for r in ch] for ch in list(structure)[0]}
-
-    def test(self):
-        from gromacs.protocols.protocol_system_prep import GromacsSystemPrep
-
-        inPdb = os.path.join(tempfile.mkdtemp(), 'two_chain_dup.pdb')
-        outPdb = inPdb.replace('_dup.pdb', '_renum.pdb')
-        self._writeTwoChainPDB(inPdb)
-
-        # before: both chains numbered 1-3 (duplicates across chains)
-        before = self._chainResNums(inPdb)
-        self.assertEqual(before['A'], [1, 2, 3])
-        self.assertEqual(before['B'], [1, 2, 3])
-
-        # run the real method with a minimal object (it only needs self._log)
-        class _Fake:
-            _log = logging.getLogger('test')
-        GromacsSystemPrep.renumberResiduesPDB(_Fake(), inPdb, outPdb)
-
-        after = self._chainResNums(outPdb)
-        allNums = [n for nums in after.values() for n in nums]
-        # no duplicates, continuous from the original start, chains preserved
-        self.assertEqual(len(allNums), len(set(allNums)), 'Duplicate residue numbers remain')
-        self.assertEqual(allNums, list(range(1, len(allNums) + 1)))
-        self.assertEqual(after['A'], [1, 2, 3])
-        self.assertEqual(after['B'], [4, 5, 6])


### PR DESCRIPTION
- Renumber Gro residues to prevent separate chains having the same number: usefull for correct pymol visualization and postprocessing -- claude generated code